### PR TITLE
split out $elements if in properties, regardless

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -155,8 +155,8 @@ export async function exportEventsToBigQuery(events: PluginEvent[], { global }: 
             let ingestedProperties = properties
             let elements = []
 
-            // only move prop to elements for the $autocapture action
-            if (eventName === '$autocapture' && properties && '$elements' in properties) {
+            // only move prop to elements if $elements in properties
+            if (properties && '$elements' in properties) {
                 const { $elements, ...props } = properties
                 ingestedProperties = props
                 elements = $elements


### PR DESCRIPTION
- split out $elements if in properties, regardless of if its an "$autocapture" event.
- this allows users to use their own plugins that may rename default "$autocapture" events to be custom names but that would still have $elements properties it would be better to split out as a seperate column in the data that lands in BigQuery.