### PR TITLE
Make BigQuery setupPlugin cheaper

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -58,6 +58,12 @@ export const setupPlugin: BigQueryPlugin['setupPlugin'] = async (meta) => {
 
     global.bigQueryTable = global.bigQueryClient.dataset(config.datasetId).table(config.tableId)
 
+    const existingFields = await meta.cache.get('bigQueryTableFieldsSynced', 0)
+
+    if (existingFields === BIG_QUERY_TABLE_FIELDS.length) {
+        return
+    }
+
     try {
         const [metadata]: TableMetadata[] = await global.bigQueryTable.getMetadata()
 
@@ -114,6 +120,7 @@ export const setupPlugin: BigQueryPlugin['setupPlugin'] = async (meta) => {
         }
     }
 
+    await meta.cache.set('bigQueryTableFieldsSynced', BIG_QUERY_TABLE_FIELDS.length)
 }
 
 


### PR DESCRIPTION
`setupPlugin` is called whenever _any_ thread on any plugin server boots or a plugin is enabled. These were failing regularly due to socket hangups.

On the other hand, this export was using setupPlugin to do BigQuery setup work over and over again. This change makes it so we do that setup only once when needed.

Related: https://github.com/PostHog/posthog/issues/12045