### PR TITLE
chore(errors): retry setupPlugin on FetchError errors

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -106,6 +106,19 @@ describe('BigQuery Export Plugin', () => {
             })
 
         })
+
+        it('throws retryError on socket errors', async () => {
+            mockedBigQueryTable.getMetadata.mockReturnValue([{ schema: { fields: [] as any } }])
+            meta.cache.get.mockResolvedValue({
+                datasetId: "wrong",
+                tableId: "1234",
+                existingFields: BIG_QUERY_TABLE_FIELDS.length
+            })
+
+            // TODO: cause google lib oauth token request to throw "socket hand
+            // up" Error.
+            expect(async () => await setupPlugin?.(meta as any)).toThrow("retryError")
+        })
     })
 
     describe('exportEvents()', () => {

--- a/index.ts
+++ b/index.ts
@@ -173,9 +173,10 @@ async function updateBigQueryTableSchema(meta: any, metadata: TableMetadata) {
                 }
             }
         } catch (error) {
-            console.log("Updating table schema failed:", error)
+            console.error("Updating table schema failed:", error)
             throw error
         }
+        // Always refresh the cache
         await meta.cache.set('cachedMetadata', {
             tableId: config.tableId,
             datasetId: config.datasetId,

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import { Plugin, RetryError } from '@posthog/plugin-scaffold'
 import { BigQuery, Table, TableField, TableMetadata } from '@google-cloud/bigquery'
+import { FetchError } from 'node-fetch'
 
 type BigQueryPlugin = Plugin<{
     global: {
@@ -50,82 +51,113 @@ export const setupPlugin: BigQueryPlugin['setupPlugin'] = async (meta) => {
     )
 
     const credentials = JSON.parse(attachments.googleCloudKeyJson.contents.toString())
-    global.bigQueryClient = new BigQuery({
-        projectId: credentials['project_id'],
-        credentials,
-        autoRetry: false,
-    })
-
-    global.bigQueryTable = global.bigQueryClient.dataset(config.datasetId).table(config.tableId)
-
-    // Note: When changing table schema in incompatible ways remember to cache-bust this.
-    const cachedMetadata = await meta.cache.get('cachedMetadata', null) as any | null
-
-    if (cachedMetadata?.datasetId === config.datasetId && cachedMetadata?.tableId === config.tableId && cachedMetadata?.existingFields === BIG_QUERY_TABLE_FIELDS.length) {
-        return
-    }
 
     try {
-        const [metadata]: TableMetadata[] = await global.bigQueryTable.getMetadata()
+        global.bigQueryClient = new BigQuery({
+            projectId: credentials['project_id'],
+            credentials,
+            autoRetry: false,
+        })
 
-        if (!metadata.schema || !metadata.schema.fields) {
-            throw new Error('Can not get metadata for table. Please check if the table schema is defined.')
+        global.bigQueryTable = global.bigQueryClient.dataset(config.datasetId).table(config.tableId)
+
+        // Note: When changing table schema in incompatible ways remember to cache-bust this.
+        const cachedMetadata = await meta.cache.get('cachedMetadata', null) as any | null
+
+        if (cachedMetadata?.datasetId === config.datasetId && cachedMetadata?.tableId === config.tableId && cachedMetadata?.existingFields === BIG_QUERY_TABLE_FIELDS.length) {
+            return
         }
 
-        const existingFields = metadata.schema.fields
-        const fieldsToAdd = BIG_QUERY_TABLE_FIELDS.filter(
-            ({ name }) => !existingFields.find((f: any) => f.name === name)
-        )
+        try {
+            const [metadata]: TableMetadata[] = await global.bigQueryTable.getMetadata()
 
-        if (fieldsToAdd.length > 0) {
-            console.info(
-                `Incomplete schema on BigQuery table! Adding the following fields to reach parity: ${JSON.stringify(
-                    fieldsToAdd
-                )}`
+            if (!metadata.schema || !metadata.schema.fields) {
+                throw new Error('Can not get metadata for table. Please check if the table schema is defined.')
+            }
+
+            const existingFields = metadata.schema.fields
+            const fieldsToAdd = BIG_QUERY_TABLE_FIELDS.filter(
+                ({ name }) => !existingFields.find((f: any) => f.name === name)
             )
 
-            let result: TableMetadata
-            try {
-                metadata.schema.fields = metadata.schema.fields.concat(fieldsToAdd)
-                ;[result] = await global.bigQueryTable.setMetadata(metadata)
-            } catch (error) {
-                const fieldsToStillAdd = BIG_QUERY_TABLE_FIELDS.filter(
-                    ({ name }) => !result.schema?.fields?.find((f: any) => f.name === name)
+            if (fieldsToAdd.length > 0) {
+                console.info(
+                    `Incomplete schema on BigQuery table! Adding the following fields to reach parity: ${JSON.stringify(
+                        fieldsToAdd
+                    )}`
                 )
 
-                if (fieldsToStillAdd.length > 0) {
-                    throw new Error(
-                        `Tried adding fields ${JSON.stringify(fieldsToAdd)}, but ${JSON.stringify(
-                            fieldsToStillAdd
-                        )} still to add. Can not start plugin.`
+                let result: TableMetadata
+                try {
+                    metadata.schema.fields = metadata.schema.fields.concat(fieldsToAdd)
+                        ;[result] = await global.bigQueryTable.setMetadata(metadata)
+                } catch (error) {
+                    if (error instanceof Error) {
+                        console.error(error.stack)
+                    }
+                    else {
+                        console.error(error)
+                    }
+
+                    const fieldsToStillAdd = BIG_QUERY_TABLE_FIELDS.filter(
+                        ({ name }) => !result.schema?.fields?.find((f: any) => f.name === name)
                     )
+
+                    if (fieldsToStillAdd.length > 0) {
+                        throw new Error(
+                            `Tried adding fields ${JSON.stringify(fieldsToAdd)}, but ${JSON.stringify(
+                                fieldsToStillAdd
+                            )} still to add. Can not start plugin.`
+                        )
+                    }
+                }
+            }
+        } catch (error) {
+            // some other error? abort!
+            if (!(error as Error).message.includes('Not found')) {
+                throw error
+            }
+            console.log(`Creating BigQuery Table - ${config.datasetId}:${config.tableId}`)
+
+            try {
+                await global.bigQueryClient
+                    .dataset(config.datasetId)
+                    .createTable(config.tableId, { schema: BIG_QUERY_TABLE_FIELDS })
+            } catch (error) {
+                // a different worker already created the table
+                if (!(error as Error).message.includes('Already Exists')) {
+                    throw error
                 }
             }
         }
+
+        await meta.cache.set('cachedMetadata', {
+            tableId: config.tableId,
+            datasetId: config.datasetId,
+            existingFields: BIG_QUERY_TABLE_FIELDS.length
+        })
     } catch (error) {
-        // some other error? abort!
-        if (!(error as Error).message.includes('Not found')) {
+        if(error instanceof Error) {
+            console.error('Error encountered in setupPlugin:', error.stack)
+        } else {
+            console.error('Error encountered in setupPlugin:', error)
+        }
+        
+        if (error instanceof FetchError) {
+            // If we get an operational fetch error then indicate that
+            // setupPlugin should be retried by raising a retryError. node-fetch
+            // (which the Google auth lib uses) raises a FetchError for
+            // "operational" errors e.g. failed sockets.
+            //
+            // See
+            // https://github.com/node-fetch/node-fetch/blob/main/docs/ERROR-HANDLING.md
+            // for details.
+            throw new RetryError(`Operational fetch error encountered: ${error.stack}`)
+        } else {
+            // Otherwise we just throw and let the caller decide what to do.
             throw error
         }
-        console.log(`Creating BigQuery Table - ${config.datasetId}:${config.tableId}`)
-
-        try {
-            await global.bigQueryClient
-                .dataset(config.datasetId)
-                .createTable(config.tableId, { schema: BIG_QUERY_TABLE_FIELDS })
-        } catch (error) {
-            // a different worker already created the table
-            if (!(error as Error).message.includes('Already Exists')) {
-                throw error
-            }
-        }
     }
-
-    await meta.cache.set('cachedMetadata', {
-        tableId: config.tableId,
-        datasetId: config.datasetId,
-        existingFields: BIG_QUERY_TABLE_FIELDS.length
-    })
 }
 
 
@@ -194,10 +226,9 @@ export const exportEvents: BigQueryPlugin['exportEvents'] = async (events, { glo
             const start = Date.now()
             await global.bigQueryTable.insert(rows, insertOptions)
             const end = Date.now() - start
-    
+
             console.log(
-                `Inserted ${events.length} ${events.length > 1 ? 'events' : 'event'} to BigQuery. Took ${
-                    end / 1000
+                `Inserted ${events.length} ${events.length > 1 ? 'events' : 'event'} to BigQuery. Took ${end / 1000
                 } seconds.`
             )
         }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "@posthog/plugin-scaffold": "1.3.4",
         "@types/generic-pool": "^3.1.9",
         "@types/jest": "^28.1.7",
+        "@types/node-fetch": "^2.6.2",
         "generic-pool": "^3.7.8",
         "jest": "^28.1.3",
         "ts-jest": "^28.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,6 +709,14 @@
     expect "^28.0.0"
     pretty-format "^28.0.0"
 
+"@types/node-fetch@^2.6.2":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
+  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.3.0.tgz#d6fed7d6bc6854306da3dea1af9f874b00783e26"
@@ -805,6 +813,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 babel-jest@^28.1.3:
   version "28.1.3"
@@ -1040,6 +1053,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1089,6 +1109,11 @@ deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -1253,6 +1278,15 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2036,6 +2070,18 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
We occasionally see socket errors e.g. `socket hang up`. Here we ensure
that the caller of setupPlugin knows that it should retry on these
errors.