### PR TITLE
Ignore autocapture by default

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -30,7 +30,7 @@
             "key": "exportEventsToIgnore",
             "name": "Events to ignore",
             "type": "string",
-            "default": "$feature_flag_called",
+            "default": "$feature_flag_called,$autocapture",
             "hint": "Comma separated list of events to ignore"
         },
         {


### PR DESCRIPTION
This event takes up a lot of space